### PR TITLE
Make native libgraphhopper working for Android

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.graphhopper.ni</groupId>
-    <artifactId>my-ni-example</artifactId>
+    <artifactId>myniexample</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -75,9 +75,12 @@
                 <artifactId>client-maven-plugin</artifactId>
                 <version>0.1.17-SNAPSHOT</version>
                 <configuration>
-<verbose>true</verbose>
+                    <resourcesList>
+                        <item>.*\\.txt$</item>
+                    </resourcesList>
                     <!-- Uncomment to run on iOS: -->
-                    <!-- <target>ios</target>-->
+                    <verbose>false</verbose>
+                    <target>android</target>
                     <mainClass>example.Example</mainClass>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-reader-osm</artifactId>
-            <version>1.0-pre20</version>
+            <version>1.0-pre30.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.xmlgraphics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,23 +71,14 @@
             </plugin>
 
             <plugin>
-                <groupId>org.graalvm.nativeimage</groupId>
-                <artifactId>native-image-maven-plugin</artifactId>
-                <version>20.0.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>native-image</goal>
-                        </goals>
-                        <phase>package</phase>
-                    </execution>
-                </executions>
+                <groupId>com.gluonhq</groupId>
+                <artifactId>client-maven-plugin</artifactId>
+                <version>0.1.17-SNAPSHOT</version>
                 <configuration>
-                    <skip>false</skip>
-                    <imageName>graphhopper</imageName>
-                    <buildArgs>
-                        --no-fallback -H:ConfigurationFileDirectories=${project.basedir}/ni-configs
-                    </buildArgs>
+<verbose>true</verbose>
+                    <!-- Uncomment to run on iOS: -->
+                    <!-- <target>ios</target>-->
+                    <mainClass>example.Example</mainClass>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -73,18 +73,24 @@
             <plugin>
                 <groupId>com.gluonhq</groupId>
                 <artifactId>client-maven-plugin</artifactId>
-                <version>0.1.17-SNAPSHOT</version>
+                <version>0.1.18</version>
                 <configuration>
                     <resourcesList>
                         <item>.*\\.txt$</item>
                     </resourcesList>
-                    <!-- Uncomment to run on iOS: -->
-                    <verbose>false</verbose>
+                    <verbose>true</verbose>
                     <target>android</target>
                     <mainClass>example.Example</mainClass>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>gluon-releases</id>
+            <url>http://nexus.gluonhq.com/nexus/content/repositories/releases/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.graphhopper.ni</groupId>
-    <artifactId>myniexample</artifactId>
+    <artifactId>graphhoppernative</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -85,12 +85,11 @@
             </plugin>
         </plugins>
     </build>
+    <!-- for client-maven-plugin -->
     <pluginRepositories>
         <pluginRepository>
             <id>gluon-releases</id>
             <url>http://nexus.gluonhq.com/nexus/content/repositories/releases/</url>
         </pluginRepository>
     </pluginRepositories>
-
-
 </project>

--- a/src/main/java/example/Example.java
+++ b/src/main/java/example/Example.java
@@ -17,16 +17,21 @@ public class Example {
         }
 
         StopWatch sw = new StopWatch().start();
-
         double lat1 = 52.5169, lon1 = 13.3884, lat2 = 52.5147, lon2 = 13.3883;
         GraphHopperOSM graphhopper = new GraphHopperOSM();
-        if (args.length == 0)
+        if (args.length == 0) {
             // assume desktop that creates the graph files
             graphhopper.setOSMFile("osm.pbf").setGraphHopperLocation("graph-cache");
-        else
-            graphhopper.setGraphHopperLocation(args[1]).setAllowWrites(false);
+        } else {
+            lat1 = Double.parseDouble(args[2]);
+            lon1 = Double.parseDouble(args[3]);
+            lat2 = Double.parseDouble(args[4]);
+            lon2 = Double.parseDouble(args[5]);
+            // assume mobile that just reads the graph files
+            graphhopper.setMemoryMapped().setGraphHopperLocation(args[1]).setAllowWrites(false);
+        }
 
-        graphhopper.setMemoryMapped().setEncodingManager(EncodingManager.create(new CarFlagEncoder())).
+        graphhopper.setEncodingManager(EncodingManager.create(new CarFlagEncoder())).
                 importOrLoad();
 
         GHResponse res = graphhopper.route(new GHRequest(new GHPoint(lat1, lon1), new GHPoint(lat2, lon2)));

--- a/src/main/java/example/Example.java
+++ b/src/main/java/example/Example.java
@@ -2,52 +2,41 @@ package example;
 
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
-import com.graphhopper.GraphHopper;
 import com.graphhopper.PathWrapper;
 import com.graphhopper.reader.osm.GraphHopperOSM;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.StopWatch;
 import com.graphhopper.util.shapes.GHPoint;
-import org.graalvm.nativeimage.IsolateThread;
-import org.graalvm.nativeimage.c.function.CEntryPoint;
 
 public class Example {
     public static void main(String[] args) {
-        System.err.println("[EXAMPLE] Hello world");
-        System.out.println("Hello world get "+args.length+" args.");
+        System.out.println("GraphHopper got " + args.length + " args.");
         for (int i = 0; i < args.length; i++) {
-            System.err.println("args["+i+"]: "+args[i]);
+            System.err.println("args[" + i + "]: " + args[i]);
         }
-        // String osmFile = (args.length == 0 || Helper.isEmpty(args[0])) ? "osm.pbf" : args[0];
+
         StopWatch sw = new StopWatch().start();
-        double dist = internalRun(52.5169, 13.3884, 52.5147, 13.3883);
-        System.out.println("distance: " + dist);
-        System.out.println("time since main method started: " + sw.stop().getSeconds());
-    }
 
-/*
-    @CEntryPoint(name = "runGH")
-    public static double runGH(IsolateThread thread, double lat1, double lon1, double lat2, double lon2) {
-        System.err.println("[EXAMPLE] runGH");
-        return internalRun(lat1, lon1, lat2, lon2);
-    }
-*/
+        double lat1 = 52.5169, lon1 = 13.3884, lat2 = 52.5147, lon2 = 13.3883;
+        GraphHopperOSM graphhopper = new GraphHopperOSM();
+        if (args.length == 0)
+            // assume desktop that creates the graph files
+            graphhopper.setOSMFile("osm.pbf").setGraphHopperLocation("graph-cache");
+        else
+            graphhopper.setGraphHopperLocation(args[1]).setAllowWrites(false);
 
-    public static double internalRun(double lat1, double lon1, double lat2, double lon2) {
-        GraphHopper graphhopper = new GraphHopperOSM().
-                setOSMFile("osm.pbf").
-                setMemoryMapped().
-                setEncodingManager(EncodingManager.create(new CarFlagEncoder())).
-                setGraphHopperLocation("graph-cache").
+        graphhopper.setMemoryMapped().setEncodingManager(EncodingManager.create(new CarFlagEncoder())).
                 importOrLoad();
+
         GHResponse res = graphhopper.route(new GHRequest(new GHPoint(lat1, lon1), new GHPoint(lat2, lon2)));
         PathWrapper pw = res.getBest();
         if (pw.hasErrors()) {
             System.out.println("route has errors " + pw.getErrors());
-            return -1;
         } else {
-            return pw.getDistance();
+            System.out.println("distance: " + pw.getDistance());
         }
+
+        System.out.println("time since main method started: " + sw.stop().getSeconds());
     }
 }

--- a/src/main/java/example/Example.java
+++ b/src/main/java/example/Example.java
@@ -34,14 +34,17 @@ public class Example {
         graphhopper.setEncodingManager(EncodingManager.create(new CarFlagEncoder())).
                 importOrLoad();
 
-        GHResponse res = graphhopper.route(new GHRequest(new GHPoint(lat1, lon1), new GHPoint(lat2, lon2)));
+        GHRequest req = new GHRequest(new GHPoint(lat1, lon1), new GHPoint(lat2, lon2));
+        GHResponse res = graphhopper.route(req);
         PathWrapper pw = res.getBest();
         if (pw.hasErrors()) {
-            System.out.println("route has errors " + pw.getErrors());
+            System.out.println("route for " + req + " has errors " + pw.getErrors());
         } else {
-            System.out.println("distance: " + pw.getDistance());
+            System.out.println("distance: " + pw.getDistance() + " for " + req);
         }
 
         System.out.println("time since main method started: " + sw.stop().getSeconds());
+        // can we use this hack to return the distance?
+        // System.exit((int) pw.getDistance());
     }
 }

--- a/src/main/java/example/Example.java
+++ b/src/main/java/example/Example.java
@@ -14,7 +14,11 @@ import org.graalvm.nativeimage.c.function.CEntryPoint;
 
 public class Example {
     public static void main(String[] args) {
-        System.out.println("Hello world");
+        System.err.println("[EXAMPLE] Hello world");
+        System.out.println("Hello world get "+args.length+" args.");
+        for (int i = 0; i < args.length; i++) {
+            System.err.println("args["+i+"]: "+args[i]);
+        }
         // String osmFile = (args.length == 0 || Helper.isEmpty(args[0])) ? "osm.pbf" : args[0];
         StopWatch sw = new StopWatch().start();
         double dist = internalRun(52.5169, 13.3884, 52.5147, 13.3883);
@@ -22,10 +26,13 @@ public class Example {
         System.out.println("time since main method started: " + sw.stop().getSeconds());
     }
 
+/*
     @CEntryPoint(name = "runGH")
     public static double runGH(IsolateThread thread, double lat1, double lon1, double lat2, double lon2) {
+        System.err.println("[EXAMPLE] runGH");
         return internalRun(lat1, lon1, lat2, lon2);
     }
+*/
 
     public static double internalRun(double lat1, double lon1, double lat2, double lon2) {
         GraphHopper graphhopper = new GraphHopperOSM().


### PR DESCRIPTION
```bash
# get latest graalvm from gluon https://github.com/gluonhq/client-samples/#linux-and-android
wget https://download2.gluonhq.com/substrate/graalvm/graalvm-svm-linux-20.1.0-ea+26.zip
# unzip this and let GRAALVM_HOME point to it
export GRAALVM_HOME=$BASE/graalvm-svm-linux-20.1-latest

# get Android SDK: https://developer.android.com/studio/#downloads
export ANDROID_SDK=$BASE/android-sdk-linux

# get Android NDK: https://developer.android.com/ndk/
export ANDROID_NDK=$BASE/android-sdk-linux/ndk/20.1.5948944/

mvn client:compile
mvn client:link
```

Then use the produced target/client/aarch64-android/libgraphhoppernative.so into distribution/ghlib/arm64-v8a/ of repo https://github.com/karussell/native-hello-world-app